### PR TITLE
ci: Lighthouse CI 워크플로우 추가

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,42 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter front build
+
+      - name: Start preview server
+        run: pnpm --filter front preview &
+
+      - name: Wait for server to be ready
+        run: npx wait-on@latest http://localhost:4173 --timeout 30000
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          urls: |
+            http://localhost:4173/
+            http://localhost:4173/posts
+            http://localhost:4173/guestbook
+          uploadArtifacts: true
+          temporaryPublicStorage: true


### PR DESCRIPTION
## 📌 Summary

- PR 생성 시 자동으로 Lighthouse 점수를 측정하는 CI 워크플로우 추가
- 결과는 PR 코멘트로 자동 게시

<br/><br/>

## 📝 Details

### Lighthouse CI 워크플로우 (`.github/workflows/lighthouse.yml`)

PR이 올라올 때마다 성능 회귀를 조기에 발견하기 어려운 문제가 있었음.

`vite preview`로 빌드 결과물을 로컬 서빙한 뒤 `treosh/lighthouse-ci-action`으로 측정. 측정 후 결과를 PR 코멘트에 자동으로 게시함.

- 트리거: `main` 브랜치 대상 PR
- 측정 페이지: `/`, `/posts`, `/guestbook`
- 결과 저장: `temporaryPublicStorage` (별도 LHCI 서버 불필요)

- 수정 파일: `.github/workflows/lighthouse.yml`
