### PR TITLE
Lighthouse CI before/after 비교 구현

### DIFF
--- a/.github/scripts/lighthouse-comment.mjs
+++ b/.github/scripts/lighthouse-comment.mjs
@@ -39,8 +39,8 @@ function readResults(dir) {
         "best-practices": Math.round((lhr.categories?.["best-practices"]?.score ?? 0) * 100),
         seo: Math.round((lhr.categories?.seo?.score ?? 0) * 100),
       };
-    } catch {
-      // skip invalid files
+    } catch (e) {
+      console.warn(`[lighthouse] ${file} 파싱 실패:`, e.message);
     }
   }
 

--- a/.github/scripts/lighthouse-comment.mjs
+++ b/.github/scripts/lighthouse-comment.mjs
@@ -1,0 +1,76 @@
+import { readFileSync, appendFileSync } from "fs";
+
+const PAGES = ["/", "/posts", "/chat", "/games", "/guestbook"];
+
+const CATEGORIES = [
+  { key: "performance", label: "Performance" },
+  { key: "accessibility", label: "Accessibility" },
+  { key: "best-practices", label: "Best Practices" },
+  { key: "seo", label: "SEO" },
+];
+
+function readManifest(dir) {
+  const manifest = JSON.parse(readFileSync(`./${dir}/manifest.json`, "utf-8"));
+  const results = {};
+
+  for (const entry of manifest) {
+    const path = new URL(entry.url).pathname || "/";
+    if (!entry.isRepresentativeRun) continue;
+    results[path] = {
+      performance: Math.round((entry.summary.performance ?? 0) * 100),
+      accessibility: Math.round((entry.summary.accessibility ?? 0) * 100),
+      "best-practices": Math.round((entry.summary["best-practices"] ?? 0) * 100),
+      seo: Math.round((entry.summary.seo ?? 0) * 100),
+    };
+  }
+
+  return results;
+}
+
+function emoji(score) {
+  if (score >= 90) return "🟢";
+  if (score >= 50) return "🟡";
+  return "🔴";
+}
+
+function diff(after, before) {
+  const d = after - before;
+  if (d > 0) return `**+${d}**`;
+  if (d < 0) return `**${d}**`;
+  return "±0";
+}
+
+const base = readManifest("base-results");
+const pr = readManifest("pr-results");
+
+const now = new Date().toLocaleString("ko-KR", { timeZone: "Asia/Seoul" });
+
+let comment = `## ⚡ Lighthouse CI 결과\n\n> 측정 시각: ${now} KST\n\n`;
+
+for (const page of PAGES) {
+  const b = base[page];
+  const p = pr[page];
+
+  comment += `### \`${page}\`\n\n`;
+
+  if (!b || !p) {
+    comment += `> 측정 실패\n\n`;
+    continue;
+  }
+
+  comment += `| 항목 | Before | After | 변화 |\n`;
+  comment += `|---|:---:|:---:|:---:|\n`;
+
+  for (const { key, label } of CATEGORIES) {
+    const before = b[key];
+    const after = p[key];
+    comment += `| ${label} | ${emoji(before)} ${before} | ${emoji(after)} ${after} | ${diff(after, before)} |\n`;
+  }
+
+  comment += "\n";
+}
+
+appendFileSync(
+  process.env.GITHUB_OUTPUT,
+  `comment<<LIGHTHOUSE_EOF\n${comment}\nLIGHTHOUSE_EOF\n`
+);

--- a/.github/scripts/lighthouse-comment.mjs
+++ b/.github/scripts/lighthouse-comment.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, appendFileSync } from "fs";
+import { readFileSync, readdirSync, appendFileSync } from "fs";
 
 const PAGES = ["/", "/posts", "/chat", "/games", "/guestbook"];
 
@@ -9,19 +9,39 @@ const CATEGORIES = [
   { key: "seo", label: "SEO" },
 ];
 
-function readManifest(dir) {
-  const manifest = JSON.parse(readFileSync(`./${dir}/manifest.json`, "utf-8"));
+function readResults(dir) {
   const results = {};
+  const dirPath = `./${dir}`;
 
-  for (const entry of manifest) {
-    const path = new URL(entry.url).pathname || "/";
-    if (!entry.isRepresentativeRun) continue;
-    results[path] = {
-      performance: Math.round((entry.summary.performance ?? 0) * 100),
-      accessibility: Math.round((entry.summary.accessibility ?? 0) * 100),
-      "best-practices": Math.round((entry.summary["best-practices"] ?? 0) * 100),
-      seo: Math.round((entry.summary.seo ?? 0) * 100),
-    };
+  let files;
+  try {
+    files = readdirSync(dirPath).filter((f) => /^lhr-.+\.json$/.test(f));
+  } catch {
+    console.error(`[lighthouse] ${dirPath} 디렉토리를 읽을 수 없음`);
+    return results;
+  }
+
+  const seen = new Set();
+
+  for (const file of files) {
+    try {
+      const lhr = JSON.parse(readFileSync(`${dirPath}/${file}`, "utf-8"));
+      const url = lhr.requestedUrl ?? lhr.finalUrl;
+      if (!url) continue;
+
+      const page = new URL(url).pathname || "/";
+      if (seen.has(page)) continue;
+      seen.add(page);
+
+      results[page] = {
+        performance: Math.round((lhr.categories?.performance?.score ?? 0) * 100),
+        accessibility: Math.round((lhr.categories?.accessibility?.score ?? 0) * 100),
+        "best-practices": Math.round((lhr.categories?.["best-practices"]?.score ?? 0) * 100),
+        seo: Math.round((lhr.categories?.seo?.score ?? 0) * 100),
+      };
+    } catch {
+      // skip invalid files
+    }
   }
 
   return results;
@@ -40,8 +60,8 @@ function diff(after, before) {
   return "±0";
 }
 
-const base = readManifest("base-results");
-const pr = readManifest("pr-results");
+const base = readResults("base-results");
+const pr = readResults("pr-results");
 
 const now = new Date().toLocaleString("ko-KR", { timeZone: "Asia/Seoul" });
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,42 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter front build
+
+      - name: Start preview server
+        run: pnpm --filter front preview &
+
+      - name: Wait for server to be ready
+        run: npx wait-on@latest http://localhost:4173 --timeout 30000
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          urls: |
+            http://localhost:4173/
+            http://localhost:4173/posts
+            http://localhost:4173/guestbook
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -8,6 +8,7 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
@@ -19,15 +20,15 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: pnpm
 
-      - name: Install @lhci/cli
-        run: npm install -g @lhci/cli
+      - name: Install CI tools
+        run: pnpm add --global @lhci/cli@0.15.1 wait-on@9.0.5
 
       # ── 1. base(main) 측정 ────────────────────────────────────
-      - name: Checkout base branch
-        run: git checkout ${{ github.base_ref }}
+      - name: Checkout base SHA
+        run: git checkout ${{ github.event.pull_request.base.sha }}
 
       - name: Install & build (base)
         run: |
@@ -38,7 +39,7 @@ jobs:
         run: pnpm --filter front preview &
 
       - name: Wait for server (base)
-        run: npx wait-on@latest http://localhost:4173 --timeout 30000
+        run: wait-on http://localhost:4173 --timeout 30000
 
       - name: Collect Lighthouse (base)
         run: |
@@ -56,8 +57,8 @@ jobs:
         run: fuser -k 4173/tcp || true
 
       # ── 2. PR branch 측정 ─────────────────────────────────────
-      - name: Checkout PR branch
-        run: git checkout ${{ github.head_ref }}
+      - name: Checkout PR SHA
+        run: git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Install & build (PR)
         run: |
@@ -68,7 +69,7 @@ jobs:
         run: pnpm --filter front preview &
 
       - name: Wait for server (PR)
-        run: npx wait-on@latest http://localhost:4173 --timeout 30000
+        run: wait-on http://localhost:4173 --timeout 30000
 
       - name: Collect Lighthouse (PR)
         run: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -49,7 +49,7 @@ jobs:
             --url=http://localhost:4173/games \
             --url=http://localhost:4173/guestbook \
             --numberOfRuns=1 \
-            --settings.chromeFlags="--no-sandbox"
+            --settings.chromeFlags="--no-sandbox --disable-dev-shm-usage"
           mv .lighthouseci base-results
 
       - name: Kill preview server
@@ -79,7 +79,7 @@ jobs:
             --url=http://localhost:4173/games \
             --url=http://localhost:4173/guestbook \
             --numberOfRuns=1 \
-            --settings.chromeFlags="--no-sandbox"
+            --settings.chromeFlags="--no-sandbox --disable-dev-shm-usage"
           mv .lighthouseci pr-results
 
       # ── 3. 비교 코멘트 게시 ───────────────────────────────────

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,36 +7,88 @@ on:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install @lhci/cli
+        run: npm install -g @lhci/cli
 
-      - name: Build
-        run: pnpm --filter front build
+      # ── 1. base(main) 측정 ────────────────────────────────────
+      - name: Checkout base branch
+        run: git checkout ${{ github.base_ref }}
 
-      - name: Start preview server
+      - name: Install & build (base)
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter front build
+
+      - name: Start preview server (base)
         run: pnpm --filter front preview &
 
-      - name: Wait for server to be ready
+      - name: Wait for server (base)
         run: npx wait-on@latest http://localhost:4173 --timeout 30000
 
-      - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@v11
+      - name: Collect Lighthouse (base)
+        run: |
+          lhci collect \
+            --url=http://localhost:4173/ \
+            --url=http://localhost:4173/posts \
+            --url=http://localhost:4173/chat \
+            --url=http://localhost:4173/games \
+            --url=http://localhost:4173/guestbook \
+            --numberOfRuns=1 \
+            --settings.chromeFlags="--no-sandbox"
+          mv .lighthouseci base-results
+
+      - name: Kill preview server
+        run: fuser -k 4173/tcp || true
+
+      # ── 2. PR branch 측정 ─────────────────────────────────────
+      - name: Checkout PR branch
+        run: git checkout ${{ github.head_ref }}
+
+      - name: Install & build (PR)
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter front build
+
+      - name: Start preview server (PR)
+        run: pnpm --filter front preview &
+
+      - name: Wait for server (PR)
+        run: npx wait-on@latest http://localhost:4173 --timeout 30000
+
+      - name: Collect Lighthouse (PR)
+        run: |
+          lhci collect \
+            --url=http://localhost:4173/ \
+            --url=http://localhost:4173/posts \
+            --url=http://localhost:4173/chat \
+            --url=http://localhost:4173/games \
+            --url=http://localhost:4173/guestbook \
+            --numberOfRuns=1 \
+            --settings.chromeFlags="--no-sandbox"
+          mv .lighthouseci pr-results
+
+      # ── 3. 비교 코멘트 게시 ───────────────────────────────────
+      - name: Generate comparison comment
+        id: comment
+        run: node .github/scripts/lighthouse-comment.mjs
+
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          urls: |
-            http://localhost:4173/
-            http://localhost:4173/posts
-            http://localhost:4173/guestbook
-          uploadArtifacts: true
-          temporaryPublicStorage: true
+          header: lighthouse
+          message: ${{ steps.comment.outputs.comment }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -36,7 +36,7 @@ jobs:
           pnpm --filter front build
 
       - name: Start preview server (base)
-        run: pnpm --filter front preview &
+        run: pnpm --filter front preview --port 4173 --strictPort &
 
       - name: Wait for server (base)
         run: wait-on http://localhost:4173 --timeout 30000
@@ -66,7 +66,7 @@ jobs:
           pnpm --filter front build
 
       - name: Start preview server (PR)
-        run: pnpm --filter front preview &
+        run: pnpm --filter front preview --port 4173 --strictPort &
 
       - name: Wait for server (PR)
         run: wait-on http://localhost:4173 --timeout 30000
@@ -82,6 +82,10 @@ jobs:
             --numberOfRuns=1 \
             --settings.chromeFlags="--no-sandbox --disable-dev-shm-usage"
           mv .lighthouseci pr-results
+
+      - name: Kill preview server (PR)
+        if: always()
+        run: fuser -k 4173/tcp || true
 
       # ── 3. 비교 코멘트 게시 ───────────────────────────────────
       - name: Generate comparison comment


### PR DESCRIPTION
## 📌 Summary

- PR 생성 시 base(main)와 PR branch를 순차 빌드·측정하여 Lighthouse 점수 before/after 비교
- 측정 완료 후 페이지별 점수 표를 PR 코멘트로 자동 게시
- `@lhci/cli` 사용, 별도 LHCI 서버 없이 `lhr-*.json` 직접 파싱


<img width="1409" height="936" alt="image" src="https://github.com/user-attachments/assets/34c1b6e3-2fdc-4438-80ec-148ecb10b3be" />


<br/><br/>

## 📝 Details

### Lighthouse CI 워크플로우 (`.github/workflows/lighthouse.yml`)

로컬에서 직접 돌리면 환경마다 수치가 달라 신뢰하기 어렵고, 페이지별 반복 측정도 번거로웠음. 

base(main)와 PR branch를 각각 `pnpm build` → `vite preview`로 로컬 서빙 → `lhci collect`로 측정. `lhr-*.json`을 직접 파싱해 before/after 비교 표를 생성하고 PR 코멘트로 게시.

- 트리거: `main` 대상 PR 오픈/업데이트
- 측정 페이지: `/`, `/posts`, `/chat`, `/games`, `/guestbook`
- Chrome 플래그: `--no-sandbox --disable-dev-shm-usage` (CI 환경 크래시 방지)
- pnpm 버전 `packageManager` 필드 자동감지, node 22 사용
- 별도 LHCI 서버 없이 `lhr-*.json` 직접 파싱 (manifest.json 의존 제거)

- 추가 파일: `.github/workflows/lighthouse.yml`
- 추가 파일: `.github/scripts/lighthouse-comment.mjs`

close #62 
