### PR TITLE
GEO 도입 - llms.txt · 구조화 데이터 · 메타태그 최적화

### DIFF
--- a/apps/front/public/robots.txt
+++ b/apps/front/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://www.gyeung-il.com/sitemap.xml

--- a/apps/front/src/app/routes/__root.tsx
+++ b/apps/front/src/app/routes/__root.tsx
@@ -5,6 +5,7 @@ import { AppProviders } from "@/app/AppProviders";
 import { GlobalStyles } from "@/app/GlobalStyles";
 import { RootLayout } from "@/app/RootLayout";
 import { FALLBACK_OG_IMAGE, SITE_NAME, SITE_URL } from "@/shared/config";
+import { buildJsonLd } from "@/shared/lib";
 
 export const Route = createRootRoute({
   head: () => ({
@@ -19,6 +20,7 @@ export const Route = createRootRoute({
       { key: "og:image:alt", property: "og:image:alt", content: "개발자 최경일의 프로필 사진" },
       { key: "og:site_name", property: "og:site_name", content: SITE_NAME },
       { key: "og:type", property: "og:type", content: "website" },
+      { key: "author", name: "author", content: "최경일" },
       { key: "article:author", property: "article:author", content: "https://github.com/inhachoi" },
       { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
       { key: "twitter:title", name: "twitter:title", content: SITE_NAME },
@@ -39,6 +41,23 @@ export const Route = createRootRoute({
         src: "https://www.googletagmanager.com/gtag/js?id=G-X3JHD025QV",
         async: true,
       },
+      buildJsonLd({
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Person",
+            name: "최경일",
+            url: SITE_URL,
+            jobTitle: "프론트엔드 개발자",
+            sameAs: ["https://github.com/inhachoi", "https://velog.io/@chlruddlf73"],
+          },
+          {
+            "@type": "WebSite",
+            name: SITE_NAME,
+            url: SITE_URL,
+          },
+        ],
+      }),
     ],
   }),
   component: Root,

--- a/apps/front/src/app/routes/posts.$slug.tsx
+++ b/apps/front/src/app/routes/posts.$slug.tsx
@@ -3,20 +3,45 @@ import { createFileRoute } from "@tanstack/react-router";
 import PostModal from "@/pages/posts-page/ui/PostModal";
 import { fetchVelogPost } from "@/shared/api";
 import { SITE_URL } from "@/shared/config";
-import { buildPageHead } from "@/shared/lib";
+import { buildJsonLd, buildPageHead } from "@/shared/lib";
 
 export const Route = createFileRoute("/posts/$slug")({
   loader: ({ params }) => {
     if (typeof window !== "undefined") return null;
     return fetchVelogPost(params.slug);
   },
-  head: ({ loaderData, params }) => ({
-    ...buildPageHead({
+  head: ({ loaderData, params }) => {
+    const pageHead = buildPageHead({
       title: loaderData?.title ? `${loaderData.title} | 개발자 최경일` : "블로그 | 개발자 최경일",
       description: loaderData?.short_description ?? "최경일의 개발 블로그",
       url: `${SITE_URL}/posts/${params.slug}`,
       image: loaderData?.thumbnail ?? undefined,
-    }),
-  }),
+    });
+
+    const extraMeta = loaderData?.released_at
+      ? [{ key: "article:published_time", property: "article:published_time", content: loaderData.released_at }]
+      : [];
+
+    const scripts = loaderData
+      ? [
+          buildJsonLd({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            headline: loaderData.title,
+            description: loaderData.short_description,
+            url: `${SITE_URL}/posts/${params.slug}`,
+            image: loaderData.thumbnail ?? undefined,
+            datePublished: loaderData.released_at,
+            author: { "@type": "Person", name: "최경일" },
+          }),
+        ]
+      : [];
+
+    return {
+      ...pageHead,
+      meta: [...pageHead.meta, ...extraMeta],
+      scripts,
+    };
+  },
   component: PostModal,
 });

--- a/apps/front/src/shared/api/velogApi.ts
+++ b/apps/front/src/shared/api/velogApi.ts
@@ -4,6 +4,7 @@ export async function fetchVelogPost(slug: string): Promise<{
   title: string;
   thumbnail: string | null;
   short_description: string;
+  released_at: string;
 } | null> {
   try {
     const res = await fetch(VELOG_API_URL, {
@@ -16,6 +17,7 @@ export async function fetchVelogPost(slug: string): Promise<{
             title
             thumbnail
             short_description
+            released_at
           }
         }`,
         variables: { username: VELOG_USERNAME, url_slug: slug },

--- a/apps/front/src/shared/lib/index.ts
+++ b/apps/front/src/shared/lib/index.ts
@@ -1,5 +1,5 @@
 export { formatYearMonth } from "./formatYearMonth";
 export { formatYearMonthDay } from "./formatYearMonthDay";
 export { linkToSlug } from "./linkToSlug";
-export { buildMeta, buildPageHead } from "./meta";
+export { buildJsonLd,buildMeta, buildPageHead } from "./meta";
 export { sortPostsByLikes } from "./sortPostsByLikes";

--- a/apps/front/src/shared/lib/meta.ts
+++ b/apps/front/src/shared/lib/meta.ts
@@ -37,3 +37,7 @@ export function buildPageHead(params: {
     links: [{ key: "canonical", rel: "canonical", href: params.url }],
   };
 }
+
+export function buildJsonLd(data: object) {
+  return { type: "application/ld+json", children: JSON.stringify(data) };
+}

--- a/apps/server/src/app.js
+++ b/apps/server/src/app.js
@@ -7,6 +7,7 @@ import guestbookRoutes from "./modules/guestbook/guestbook.routes.js";
 import postsRoutes from "./modules/posts/posts.routes.js";
 import chatRoutes from "./modules/chat/chat.routes.js";
 import analyticsRoutes from "./modules/analytics/analytics.routes.js";
+import llmsRoutes from "./modules/llms/llms.routes.js";
 
 const app = express();
 const allowedOrigins = ["http://localhost:5173", "https://www.gyeung-il.com"];
@@ -35,5 +36,6 @@ app.use("/api/guestbook", guestbookRoutes);
 app.use("/api/posts", postsRoutes);
 app.use("/api/chat", chatRoutes);
 app.use("/api/analytics", analyticsRoutes);
+app.use("/llms.txt", llmsRoutes);
 
 export default app;

--- a/apps/server/src/modules/llms/llms.routes.js
+++ b/apps/server/src/modules/llms/llms.routes.js
@@ -1,0 +1,61 @@
+import express from "express";
+
+const router = express.Router();
+
+let cache = null;
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+router.get("/", async (req, res) => {
+  try {
+    if (cache && Date.now() < cache.expiresAt) {
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      return res.send(cache.data);
+    }
+
+    const response = await fetch("https://v2.velog.io/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        operationName: "Posts",
+        query: `query Posts($username: String, $limit: Int) {
+          posts(username: $username, limit: $limit) {
+            title
+            url_slug
+            short_description
+          }
+        }`,
+        variables: { username: "chlruddlf73", limit: 20 },
+      }),
+    });
+
+    const result = await response.json();
+    const posts = result.data?.posts ?? [];
+
+    const postLines = posts
+      .map((p) => `- [${p.title}](https://www.gyeung-il.com/posts/${p.url_slug}): ${p.short_description}`)
+      .join("\n");
+
+    const text = `# 개발자 최경일 (gyeung-il.com)
+> UX와 소통에 집중하는 프론트엔드 개발자 최경일의 개인 홈페이지.
+
+## 주요 페이지
+- [블로그](https://www.gyeung-il.com/posts): 프론트엔드 개발 관련 글 모음
+- [방명록](https://www.gyeung-il.com/guestbook): 방문자 메시지
+- [AI 채팅](https://www.gyeung-il.com/chat): Claude 기반 AI 채팅
+- [미니게임](https://www.gyeung-il.com/games): 직접 만든 미니게임 모음
+
+## 최근 블로그 포스트
+${postLines}
+`;
+
+    cache = { data: text, expiresAt: Date.now() + CACHE_TTL_MS };
+
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    return res.send(text);
+  } catch (err) {
+    console.error("llms.txt 오류:", err);
+    return res.status(500).send("오류가 발생했습니다.");
+  }
+});
+
+export default router;


### PR DESCRIPTION
## 📌 Summary

- AI 검색 엔진 노출 대응을 위한 GEO(Generative Engine Optimization) 도입
- llms.txt 동적 엔드포인트, JSON-LD 구조화 데이터, 메타태그 보강 적용
- 측정 기준 AI Score: **59점 → 예상 99점** (스키마 마크업 0→25, llms.txt 0→15)

`before`

<img width="1680" height="731" alt="image" src="https://github.com/user-attachments/assets/96172322-4254-4578-93db-72e8a993cff4" />

<br/>

`after`

<img width="1676" height="750" alt="image" src="https://github.com/user-attachments/assets/580eee53-52d0-4f8d-95f5-d7f5ca41742e" />


<br/><br/>

## 📝 Details

### llms.txt 동적 엔드포인트 (`apps/server/src/modules/llms/llms.routes.js`)

AI 크롤러(Perplexity 등)가 사이트 정보를 파싱할 수 있는 표준 파일이 없어 LLM 친화적 정보 제공 항목에서 0점.

Express 서버에 `GET /llms.txt` 엔드포인트를 신규 추가. Velog GraphQL API에서 최신 포스트 20개를 가져와 llms.txt 형식으로 응답하며, in-memory 캐시로 1시간마다 갱신해 불필요한 API 호출을 방지.

- 수정 파일: `apps/server/src/modules/llms/llms.routes.js`, `apps/server/src/app.js`

---

### buildJsonLd 헬퍼 및 velogApi 확장 (`apps/front/src/shared/lib/meta.ts`)

JSON-LD 스크립트 태그를 일관되게 생성하는 헬퍼 함수가 없어 라우트마다 직접 구성해야 하는 상황.

`buildJsonLd(data)` 헬퍼를 `shared/lib/meta.ts`에 추가해 TanStack Router `head()`의 `scripts` 배열에 바로 사용할 수 있도록 구성. 포스트 작성일 노출을 위해 `velogApi`의 `ReadPost` 쿼리에 `released_at` 필드도 추가.

- 수정 파일: `apps/front/src/shared/lib/meta.ts`, `apps/front/src/shared/lib/index.ts`, `apps/front/src/shared/api/velogApi.ts`

---

### 전역 Person·WebSite JSON-LD 및 author 메타태그 (`apps/front/src/app/routes/__root.tsx`)

AI가 사이트 운영자 정보를 구조화된 형태로 파악할 수 없어 스키마 마크업 항목 0점.

`__root.tsx`의 `head()`에 schema.org `Person`(이름, 직함, GitHub·Velog `sameAs`)과 `WebSite` JSON-LD를 삽입. `<meta name="author">` 메타태그도 함께 추가.

- 수정 파일: `apps/front/src/app/routes/__root.tsx`

---

### 포스트 상세 BlogPosting JSON-LD 및 published_time (`apps/front/src/app/routes/posts.$slug.tsx`)

개별 포스트에 저자·날짜 정보가 구조화 데이터로 없어 AI 인용 시 출처 정보가 불명확.

`posts.$slug.tsx`에 schema.org `BlogPosting` JSON-LD(headline, description, url, image, datePublished, author)를 삽입. `article:published_time` 메타태그도 추가. `loaderData`가 null인 클라이언트 사이드 렌더링 시는 안전하게 skip.

- 수정 파일: `apps/front/src/app/routes/posts.$slug.tsx`

---

### robots.txt Sitemap 참조 추가 (`apps/front/public/robots.txt`)

크롤러가 sitemap.xml을 직접 탐색해야 해서 발견 누락 가능성 존재.

`Sitemap:` 지시어를 추가해 AI·검색 크롤러가 robots.txt 접근 즉시 sitemap.xml을 발견하도록 개선.

- 수정 파일: `apps/front/public/robots.txt`

<br/>

close #64